### PR TITLE
If a URL points to a directory, look for an index.html

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -28,19 +28,28 @@ module.exports = function createHandler({
     const filepath = join(cwd, ...pathSegments);
 
     // Basic request caching
-    if (!cache[url]) {
-      try {
-        fs.accessSync(filepath);
-
-        if (fs.statSync(filepath).isFile()) {
-          cache[url] = filepath;
-        }
-      } catch (err) {
-        //
-      }
-    }
-
-    // redirect unmet requests to indexPath
-    callback({ path: cache[url] || indexPath });
+    cache[url] = cache[url] || resolvePath(filepath, indexPath);
+    callback({ path: cache[url] });
   };
 };
+
+function resolvePath(filepath, defaultPath) {
+  let stat;
+  try {
+    fs.accessSync(filepath);
+    stat = fs.statSync(filepath);
+  } catch (e) {
+    // file doesn't exist or isn't accessible
+    return defaultPath;
+  }
+
+  if (stat.isFile()) {
+    return filepath;
+  } else if (stat.isDirectory()) {
+    // It's a directory, so look for an 'index.html' inside it
+    return resolvePath(join(filepath, 'index.html'), defaultPath);
+  } else {
+    // Not a file or directory, so we don't really know how to handle it
+    return defaultPath;
+  }
+}

--- a/tests/unit/handler-test.js
+++ b/tests/unit/handler-test.js
@@ -22,6 +22,9 @@ describe('handler', () => {
       isFile() {
         return mockFiles.indexOf(path) !== -1;
       },
+      isDirectory() {
+        return mockDirs.indexOf(path) !== -1;
+      },
     }));
   });
 
@@ -89,6 +92,28 @@ describe('handler', () => {
     mockDirs.push('.');
     mockFiles.push('foo.html');
     return handlerExec('serve://dist', {
+      cwd: '.',
+      indexPath: join('.', 'foo.html'),
+    }).then(path => {
+      assert.equal(path, join('.', 'foo.html'));
+    });
+  });
+
+  it('looks for index.html in directories', () => {
+    mockDirs.push('foo');
+    mockFiles.push(join('foo', 'index.html'));
+    return handlerExec('serve://dist/foo', {
+      cwd: '.',
+      indexPath: join('.', 'foo.html'),
+    }).then(path => {
+      assert.equal(path, join('foo', 'index.html'));
+    });
+  });
+
+  it('falls back on indexPath when directory does not contain index.html', () => {
+    mockDirs.push('foo');
+    mockFiles.push(join('foo', 'notindex.html'));
+    return handlerExec('serve://dist/foo', {
       cwd: '.',
       indexPath: join('.', 'foo.html'),
     }).then(path => {


### PR DESCRIPTION
This is the default behavior of web servers. We still have the ultimate fallback to the indexPath if we can't find index.html, but now if you specify a directory that contains an index.html, we'll serve that index.html.